### PR TITLE
Image Links on IO

### DIFF
--- a/lessons/Co2Solubility.md
+++ b/lessons/Co2Solubility.md
@@ -6,7 +6,7 @@ This experiment, like the sugar solubility, is about the the solubility of thing
 To learn about the difference in gas and solid solubility.
 Make science fun!  This is in contract to solids into liquids, ( [see Sugar Solubility](SugarSolubility.md) )
 
-![Image of a chart graphing the co2 and sucrose solubility](/images/ChartCo2andSugar.png)
+![Image of a chart graphing the co2 and sucrose solubility](../images/ChartCo2andSugar.png)
 
 ## Materials
 
@@ -24,7 +24,7 @@ Clean Up: 5 minutes
 
 ## Lesson
 
-![Image of Bottle filling with hot water](/images/Hotwaterco2experiment.jpg)
+![Image of Bottle filling with hot water](../images/Hotwaterco2experiment.jpg)
 
 Steps:
 

--- a/lessons/CoinBattery.md
+++ b/lessons/CoinBattery.md
@@ -12,7 +12,7 @@ Using a voltmeter to show the effect with the coin battery is simpler but less s
 
  This is listed as a 5th grade science project, but first graders should be able to do this.
 
-![Parts](./../images/Battery_Parts.jpg)
+![Parts](../images/Battery_Parts.jpg)
 
 ## Goals
 

--- a/lessons/CoinBattery.md
+++ b/lessons/CoinBattery.md
@@ -46,7 +46,7 @@ The only preparation needed for the coin battery project is to gather the materi
 OPTIONAL:
 A range of LED diodes at different wavelengths.  Due to the relationship between energy and wavelength, different wavelengths take different amount of energy to light up an LED. The red LED turns on with the the lowest voltage.  This setup allows the students to see the effect of stacking different amounts of batteries in series.
 
-![Planks Constant](./../images/Battery_LED_stand.jpg)
+![Planks Constant](../images/Battery_LED_stand.jpg)
 
 See [Planck Constant](https://en.wikipedia.org/wiki/Planck_constant) for more information on this relationship.
 
@@ -65,7 +65,7 @@ If the light bulb project is being performed at the same time as the coin batter
 
 ### Steps: Building The Battery:
 
-![Parts](./images/Battery_Parts.jpg)
+![Parts](../images/Battery_Parts.jpg)
 
 * Add a small amount of water in the glass or bowl. 1/4 cup should do just fine. Mix in enough salt such that a few grains no longer dissolve after stirring.
 

--- a/lessons/Dyecolor.md
+++ b/lessons/Dyecolor.md
@@ -8,12 +8,12 @@ Learn about the difference in cold water and hot water, and why!
 
 | Cold Water with Food Dye |
 |:------: |
-| ![Image of purple food dye in ice water, food dye settling at the bottom of the glass.](/images/coldwaterfooddye.jpg) |
+| ![Image of purple food dye in ice water, food dye settling at the bottom of the glass.](../images/coldwaterfooddye.jpg) |
 
 
 | Hot Water with Food Dye|
 |:------: |
-| ![Image of purple food dye in hot water, food dye in a cloud in the center of the glass.](/images/hotwaterfooddye.jpg)|
+| ![Image of purple food dye in hot water, food dye in a cloud in the center of the glass.](../images/hotwaterfooddye.jpg)|
 
 
 ## Materials
@@ -49,6 +49,6 @@ Once again easy!
 ## Pointers
 
 Use a food color that you can easily see in the water.
-* Point out the that hot water has more thermal energy.  We can see this energy by watching how the dye gets **mixed** into the water.  More energy the faster the molecules "move" causing the dye to get mixed faster. 
+* Point out the that hot water has more thermal energy.  We can see this energy by watching how the dye gets **mixed** into the water.  More energy the faster the molecules "move" causing the dye to get mixed faster.
 
 ## References

--- a/lessons/GlowWater.md
+++ b/lessons/GlowWater.md
@@ -6,7 +6,7 @@ This sounded AWESOME: Physics and Chemistry combined.  Nifty visible proof in wh
 Two chemicals create a glowing mixture that’s a window
 into the weird world of quantum physics ( [QuantumPhysicsInGlass](https://www.popsci.com/diy/article/2008-07/quantum-physics-glass))
 
-![From Popsci](images/glassquantum.png)
+![From Popsci](../images/glassquantum.png)
 
 
 ## Why this experiment is a  NO go.

--- a/lessons/IceCream.md
+++ b/lessons/IceCream.md
@@ -4,7 +4,7 @@ Dry ice ice cream is a quick easy way to make Ice Cream. and learn a little food
 
 Did you know that: *Air makes up anywhere from 30% to 50% of the total volume of ice cream.*  Guess that is why one can make Ice Cream Floats!
 
-![Science Ice cream Image](/images/1450816777062.jpg)
+![Science Ice cream Image](../images/1450816777062.jpg)
 
 ## Goal
 Cooking is science too!  

--- a/lessons/LaserJello.md
+++ b/lessons/LaserJello.md
@@ -4,7 +4,7 @@ Not quite Sharks With Lasers.
 However, jello makes an excellent medium that kids can use to design and
 create lenses to explore properties of light.
 
-| ![Laser Jello](/images/jello_beakerlaser.jpg ) | ![Laser Jello](/images/jello_greenlaser.jpg ) |
+| ![Laser Jello](../images/jello_beakerlaser.jpg ) | ![Laser Jello](../images/jello_greenlaser.jpg ) |
 |:--|:--|
 | Internal Refraction | Angle change |
 
@@ -58,4 +58,4 @@ RULEs:
 
 ### Bend light 180 degrees and hit a target.
 
-![Laser Jello](/images/jello_bunlaser.jpg )
+![Laser Jello](../images/jello_bunlaser.jpg )

--- a/lessons/Materialsinwater.md
+++ b/lessons/Materialsinwater.md
@@ -9,7 +9,7 @@ Learn how different materials mix into water!
 
 ## Materials
 
-![Image of all of the materials next to each other](/images/materialsetup.jpg)
+![Image of all of the materials next to each other](../images/materialsetup.jpg)
 
 1. Clear Vinegar
 2. Rubbing Alcohol

--- a/lessons/PlasmaGrape.md
+++ b/lessons/PlasmaGrape.md
@@ -1,10 +1,10 @@
 # Plasma with Grapes
  WARNING: THIS MAY DESTROY YOUR MICROWAVE
- ![Plasma Gif](/images/plasma_sm.gif)
+ ![Plasma Gif](../images/plasma_sm.gif)
 
- | ![Plasma Setup](/images/plasma_setup.jpg ) |
+ | ![Plasma Setup](../images/plasma_setup.jpg ) |
  |:--|
- | ![Plasma After](/images/plasma_after.jpg) |
+ | ![Plasma After](../images/plasma_after.jpg) |
 ## Goal
 Show that plasma is a state of matter that can be made at home, just like you can do with the other (main) three: Solid, Liquid and Gas.
 

--- a/lessons/SinkingMarshmallows.md
+++ b/lessons/SinkingMarshmallows.md
@@ -3,16 +3,16 @@ Adapted from [How Things Work: How To Sink A Marshmallow](https://www.parenting.
 ### The purpose of this project is to find out whether or not the marshmallow sinks with the ingredients added.
 Time: 5 to 10 minutes   
 Skill Level: Medium   
-The experiment: Marshmallows are filled with air, which makes them float. 
+The experiment: Marshmallows are filled with air, which makes them float.
 
-![Marshmallow](/images/sinkingmarshmallows.jpg)
+![Marshmallow](../images/sinkingmarshmallows.jpg)
 
 ## Materials:
 * Mini marshmallows
 * Large clear bowl of water
 * Cornstarch
 * Flat surface, such as a cutting board, tabletop or counter
-* Spoon (optional ) 
+* Spoon (optional )
 
 ## What to do:
 1. Drop a marshmallow into the water. Does it sink or float?  

--- a/lessons/SoapFoam.md
+++ b/lessons/SoapFoam.md
@@ -1,6 +1,6 @@
 
 # Soap Foam AKA Elephant Soap, or Unicorn Poo
-![Unicorn Poop Image](/images/UnicornPoo.png)
+![Unicorn Poop Image](../images/UnicornPoo.png)
 
 Hydrogen Peroxide (H2O2) when mixed with a yeast (a catalyst) produces Water (H2O), Oxygen (O) and HEAT.
 Add soap to capture the Oxygen creates a hot, soapy, mixture.
@@ -17,7 +17,7 @@ In addition, the combination, or ratio of the atoms in a molecule also affect is
 
 
 ## Materials
-![Prep Material](/images/h2o2_prep.jpg)
+![Prep Material](../images/h2o2_prep.jpg)
 * Empty CLEAN bottle: OJ, soda, beer, wine, water etc.
 * Measuring cup and measuring spoons
 * Salon-grade hydrogen peroxide (6-12 percent by volume; 20, 30 or 40 clear developer)
@@ -48,7 +48,7 @@ Pour yeast mixture into funnel or directly into the soda bottle, quickly remove 
 
 
 ### Example with OJ bottle:
-![OJ bottle used for soap foam experiment](/images/soapfoam_ojcontainer.png)
+![OJ bottle used for soap foam experiment](../images/soapfoam_ojcontainer.png)
 
 
 ### Smaller bottles work too!
@@ -57,7 +57,7 @@ If you are using small 16oz water bottle use about 1/2 cup of H2O2.
 
 | Setup | Working | Worked |
 |:----: | :----: |:----: |
-| ![Soap Foam Start](/images/soapfoam1.png) | ![Soap Foam Middle](/images/soapfoam2.png) | ![Soap Foam End](/images/soapfoam3.png) |
+| ![Soap Foam Start](../images/soapfoam1.png) | ![Soap Foam Middle](../images/soapfoam2.png) | ![Soap Foam End](../images/soapfoam3.png) |
 
 
 ## Time
@@ -107,9 +107,9 @@ Soap is not the only way to capture the Oxygen.  You can use a balloon.
 * Tip the yeast into to bottle.
 
 
-| ![step 1](/images/h2o2_balloon0.jpg) |![step 2](/images/h2o2_balloon1.jpg)
+| ![step 1](../images/h2o2_balloon0.jpg) |![step 2](../images/h2o2_balloon1.jpg)
 | ----| ---|
-| ![step 3](/images/h2o2_balloon2.jpg)| ![step 4](/images/h2o2_balloon3.jpg)|
+| ![step 3](../images/h2o2_balloon2.jpg)| ![step 4](../images/h2o2_balloon3.jpg)|
 
 
 ## References

--- a/lessons/Sodium.md
+++ b/lessons/Sodium.md
@@ -4,7 +4,7 @@
 Give kids first hand experience with chemical properties.
 
 Let them see how those properties change significantly when a molecule is formed.  
-![Sodium](/images/sodium.png)
+![Sodium](../images/sodium.png)
 
 ## Talking Points
 Salt is made up of two elements: Sodium and Chlorine.
@@ -54,7 +54,7 @@ Surprisingly easy to get sodium.
 
 ***Danger level: High***
 
-READ Sodium's [msds sheet](./doc/msds_sodium.pdf)
+READ Sodium's [msds sheet](../doc/msds_sodium.pdf)
 
 
 ## Salt and Sodium compare:
@@ -114,4 +114,4 @@ Make sure everyone is wearing safety glasses
 
 ## References
 * [PH Defined](https://en.wikipedia.org/wiki/PH)
-* [Sodium msds sheet](./doc/msds_sodium.pdf)
+* [Sodium msds sheet](../doc/msds_sodium.pdf)

--- a/lessons/SugarSolubility.md
+++ b/lessons/SugarSolubility.md
@@ -7,7 +7,7 @@ This is an experiment about the saturation point of solids in liquids (specifica
 To learn how solubility of solids changes as a function of temperature.
 Make science fun with a ***sweet*** experiment.
 
-![Image of a chart graphing the co2 and sucrose solubility](/images/ChartCo2andSugar.png)
+![Image of a chart graphing the co2 and sucrose solubility](../images/ChartCo2andSugar.png)
 
 ## Materials
 
@@ -18,7 +18,7 @@ Make science fun with a ***sweet*** experiment.
 - [ ] A piece of paper (to record your results)
 - [ ] Cold, warm, and hot water
 
-![Image of the sugar water set up, sugar thermometer, teaspoon, and jars.](/images/Sugarwater2.jpg)
+![Image of the sugar water set up, sugar thermometer, teaspoon, and jars.](../images/Sugarwater2.jpg)
 
 ## Time
 

--- a/lessons/spectroscope.md
+++ b/lessons/spectroscope.md
@@ -11,7 +11,7 @@ You can also use this to see the difference between florescent light bulbs and L
 ## Goal
 Make a spectroscope to see different color of light.
 
-| ![Full Spectrum](/images/fullspectrumlight.jpg ) | ![florescent](/images/Florecent_light.jpg ) |
+| ![Full Spectrum](../images/fullspectrumlight.jpg ) | ![florescent](../images/Florecent_light.jpg ) |
 |:--|:--|
 | Full Spectrum Light| Florescent Light |
 
@@ -26,9 +26,9 @@ Make a spectroscope to see different color of light.
 or purchase a spectroscope for ~ 8 dollars.
 
 
-| ![Setup](/images/spectroscope.jpg ) |
+| ![Setup](../images/spectroscope.jpg ) |
 |:--|
-| ![inside spectro scope](/images/spectroscope_inner.jpg ) |
+| ![inside spectro scope](../images/spectroscope_inner.jpg ) |
 | A spectroscope innards |
 
 ### Cost ~ $3.00- 14.00
@@ -41,7 +41,7 @@ or purchase a spectroscope for ~ 8 dollars.
 Longer if you talk about how it works and try to calculate
 
 ## Lesson
-![Spectrum of light](/images/Visible_spec.png)
+![Spectrum of light](../images/Visible_spec.png)
 Light is part of the electromagnetic spectrum that we can see (400nm to 750nm).  
 White light is made up of multiple wavelengths that are combined.  
 


### PR DESCRIPTION
Fixed broken links on the lesson pages and also documents links in lessons.
Images needed a "../" path to work.
